### PR TITLE
Remove current implementation of SponsorLink for now

### DIFF
--- a/src/CloudStorageAccount.Source/CloudStorageAccount.Source.csproj
+++ b/src/CloudStorageAccount.Source/CloudStorageAccount.Source.csproj
@@ -23,7 +23,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\CloudStorageAccount.CodeAnalysis\CloudStorageAccount.CodeAnalysis.csproj" ReferenceOutputAssembly="false" OutputItemType="None" />
+    <!--<ProjectReference Include="..\CloudStorageAccount.CodeAnalysis\CloudStorageAccount.CodeAnalysis.csproj" ReferenceOutputAssembly="false" OutputItemType="None" />-->
   </ItemGroup>
   
   <ItemGroup>

--- a/src/CloudStorageAccount/CloudStorageAccount.csproj
+++ b/src/CloudStorageAccount/CloudStorageAccount.csproj
@@ -24,7 +24,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\CloudStorageAccount.CodeAnalysis\CloudStorageAccount.CodeAnalysis.csproj" ReferenceOutputAssembly="false" OutputItemType="None" />
+    <!--<ProjectReference Include="..\CloudStorageAccount.CodeAnalysis\CloudStorageAccount.CodeAnalysis.csproj" ReferenceOutputAssembly="false" OutputItemType="None" />-->
   </ItemGroup>
   
 </Project>


### PR DESCRIPTION
Now that SponsorLink is OSS and based on received feedback it will change in many ways moving forward, we'll for now remove the current implementation from the package to address the issues that were raised.

See https://github.com/devlooped/SponsorLink